### PR TITLE
Add sample customer data file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,37 @@
+# AI Content Strategy App
 
+This project provides a simple Streamlit application for running marketing experiments on SME customer data.
+
+## Features
+
+- Upload a CSV file containing customer information.
+- Automatically determines cluster counts for the `industry` column and for the `product` column inside each industry cluster.
+- Performs clustering with K-means and summarises each industry cluster by total amount, average credit score and average tenure, ranking them by total amount.
+- Allows you to pick how many of the ranked industry and product clusters to include when configuring the experiment.
+- Lets you provide separate keywords for marketing messages and product propositions, specify how many of each to generate, adjust a creative temperature slider and optionally generate suggestions using the **Gemma-2B-IT** model hosted on Hugging Face.
+- Randomly assigns customers to message variants.
+
+## Usage
+
+Install the dependencies and run the Streamlit app:
+
+```bash
+pip install -r requirements.txt
+streamlit run streamlit_app.py
+```
+
+Upload a CSV containing lowercase column names:
+
+- `industry`
+- `product`
+- `amount`
+- `credit_score`
+- `tenure`
+
+The provided `sample_customers.csv` includes these columns as well as the
+optional fields `cid`, `company_name` and `start_date`. Column names are
+automatically normalised to lowercase after upload.
+
+Follow the on-screen instructions to explore clusters, configure your experiment, provide message and product keywords separately and (optionally) generate AI-powered content suggestions.
+
+Gemma model generation requires internet access and may take a long time on first run.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+streamlit
+pandas
+numpy
+scikit-learn
+torch
+transformers

--- a/sample_customers.csv
+++ b/sample_customers.csv
@@ -1,0 +1,101 @@
+cid,company_name,industry,product,amount,credit_score,start_date,tenure
+CID0001,Sanchez *** Group,Manufacturing,Trade Credit,66852.3,808,2019-06-13,6.06
+CID0002,Alvarado *** Co.,Construction,Loan,7684.62,694,2016-12-14,8.55
+CID0003,Smith *** Co.,Manufacturing,Loan,407428.3,754,2023-12-10,1.56
+CID0004,Keller *** Bhd,Healthcare,Invoice Financing,77049.45,327,2016-09-23,8.77
+CID0005,Allen *** Enterprises,Finance,Equipment Leasing,456189.76,586,2023-04-16,2.21
+CID0006,Long *** Ltd,Technology,Loan,205523.59,388,2017-02-21,8.36
+CID0007,Walker *** Holdings,Finance,Invoice Financing,114621.91,795,2023-02-18,2.37
+CID0008,Ross *** Bhd,Manufacturing,Invoice Financing,335301.05,429,2021-10-10,3.73
+CID0009,Porter *** Ltd,Technology,Loan,297114.39,478,2023-01-01,2.5
+CID0010,Weaver *** Enterprises,Retail,Equipment Leasing,316799.83,613,2016-04-17,9.21
+CID0011,Smith *** Group,Finance,Invoice Financing,163617.47,568,2024-11-15,0.63
+CID0012,Jones *** Co.,Finance,Invoice Financing,476801.71,641,2021-04-13,4.22
+CID0013,James *** Co.,Logistics,Overdraft,443848.3,408,2017-01-24,8.44
+CID0014,Gordon *** Group,Retail,Invoice Financing,186213.54,586,2023-06-24,2.03
+CID0015,Hahn *** Holdings,Healthcare,Loan,350865.15,824,2019-06-15,6.05
+CID0016,Weeks *** Enterprises,Retail,Loan,135530.59,595,2016-08-07,8.9
+CID0017,Gomez *** Ltd,Finance,Loan,492007.57,589,2017-09-15,7.8
+CID0018,Moore *** Ltd,Manufacturing,Loan,401195.59,301,2018-06-05,7.08
+CID0019,Cordova *** Co.,Finance,Trade Credit,211756.78,748,2022-12-14,2.55
+CID0020,Arnold *** Ltd,Logistics,Trade Credit,56627.14,346,2017-07-15,7.97
+CID0021,Watson *** Co.,Retail,Invoice Financing,389811.66,642,2015-07-12,9.98
+CID0022,Blackwell *** Ltd,Finance,Loan,274475.99,345,2021-08-31,3.84
+CID0023,Norton *** Bhd,Logistics,Invoice Financing,347511.99,403,2018-04-17,7.21
+CID0024,Allison *** Bhd,Healthcare,Loan,196257.66,510,2021-05-07,4.16
+CID0025,Moore *** Ltd,Technology,Overdraft,59596.43,383,2024-08-06,0.91
+CID0026,Rollins *** Group,Logistics,Overdraft,244903.45,551,2019-10-09,5.73
+CID0027,Lozano *** Holdings,Manufacturing,Trade Credit,360367.67,618,2021-11-19,3.62
+CID0028,Buchanan *** Ltd,Healthcare,Equipment Leasing,496599.35,484,2016-11-07,8.65
+CID0029,Bradley *** Holdings,Healthcare,Invoice Financing,166264.36,687,2020-06-14,5.05
+CID0030,Taylor *** Bhd,Healthcare,Trade Credit,210462.02,827,2020-12-08,4.57
+CID0031,Cowan *** Holdings,Manufacturing,Loan,457707.17,393,2015-07-08,9.99
+CID0032,Ray *** Group,Construction,Invoice Financing,49751.77,528,2022-08-27,2.85
+CID0033,Rangel *** Group,Technology,Equipment Leasing,107610.46,317,2018-02-23,7.36
+CID0034,Reid *** Group,Finance,Overdraft,497131.26,684,2019-11-07,5.65
+CID0035,Ramirez *** Ltd,Technology,Overdraft,269239.41,461,2017-12-05,7.58
+CID0036,Hayes *** Enterprises,Retail,Loan,224455.5,374,2016-03-06,9.33
+CID0037,Torres *** Bhd,Healthcare,Trade Credit,221631.43,606,2024-09-06,0.82
+CID0038,Walsh *** Co.,Finance,Equipment Leasing,69767.75,528,2023-04-09,2.23
+CID0039,Knight *** Ltd,Logistics,Equipment Leasing,149320.57,340,2016-01-04,9.49
+CID0040,Mcclure *** Ltd,Logistics,Loan,356608.37,779,2024-09-15,0.8
+CID0041,Ponce *** Enterprises,Healthcare,Loan,427586.39,601,2022-06-22,3.03
+CID0042,Bean *** Group,Construction,Equipment Leasing,109995.55,338,2017-06-28,8.01
+CID0043,Oneill *** Group,Technology,Trade Credit,89284.87,642,2022-08-20,2.87
+CID0044,Welch *** Ltd,Construction,Invoice Financing,393472.57,707,2024-06-14,1.05
+CID0045,Petersen *** Bhd,Manufacturing,Trade Credit,197574.11,401,2021-10-26,3.69
+CID0046,Valenzuela *** Enterprises,Finance,Invoice Financing,428646.47,850,2024-11-16,0.63
+CID0047,Dudley *** Enterprises,Construction,Invoice Financing,403193.68,556,2015-11-28,9.6
+CID0048,Mason *** Co.,Construction,Invoice Financing,197652.27,568,2021-11-25,3.6
+CID0049,Macdonald *** Holdings,Retail,Trade Credit,382610.84,698,2021-02-20,4.36
+CID0050,Shaw *** Group,Manufacturing,Invoice Financing,150262.17,708,2023-12-14,1.55
+CID0051,Jackson *** Enterprises,Retail,Overdraft,129310.96,352,2022-09-10,2.81
+CID0052,Burke *** Enterprises,Technology,Invoice Financing,202043.92,567,2024-04-20,1.2
+CID0053,Bates *** Ltd,Manufacturing,Equipment Leasing,444218.06,591,2019-06-01,6.09
+CID0054,Sullivan *** Co.,Technology,Trade Credit,153304.08,461,2023-02-27,2.35
+CID0055,Clayton *** Ltd,Healthcare,Equipment Leasing,35050.53,377,2017-03-25,8.27
+CID0056,Lopez *** Group,Construction,Equipment Leasing,291511.08,333,2016-06-27,9.02
+CID0057,Allison *** Ltd,Logistics,Trade Credit,304556.5,541,2018-09-09,6.81
+CID0058,Sanders *** Co.,Technology,Loan,251001.93,790,2024-04-08,1.23
+CID0059,Nelson *** Co.,Technology,Equipment Leasing,410668.56,370,2016-12-21,8.53
+CID0060,Steele *** Ltd,Manufacturing,Loan,189786.64,369,2016-03-20,9.29
+CID0061,Faulkner *** Ltd,Logistics,Invoice Financing,251370.85,642,2021-06-08,4.07
+CID0062,Evans *** Group,Technology,Loan,48058.1,663,2018-02-24,7.35
+CID0063,Morgan *** Group,Construction,Overdraft,220822.74,432,2020-06-26,5.02
+CID0064,Morrison *** Ltd,Manufacturing,Equipment Leasing,136354.79,791,2020-12-27,4.51
+CID0065,Moore *** Enterprises,Construction,Trade Credit,255426.16,643,2019-03-19,6.29
+CID0066,Powers *** Bhd,Retail,Equipment Leasing,379785.87,755,2017-09-21,7.78
+CID0067,Patterson *** Group,Technology,Invoice Financing,387837.09,430,2018-10-05,6.74
+CID0068,Hernandez *** Co.,Manufacturing,Overdraft,77607.7,393,2022-11-21,2.61
+CID0069,Bell *** Enterprises,Logistics,Trade Credit,211829.78,321,2015-07-17,9.96
+CID0070,Stephenson *** Group,Finance,Invoice Financing,423980.83,801,2017-02-26,8.35
+CID0071,Johnson *** Ltd,Manufacturing,Loan,192297.87,824,2017-04-29,8.18
+CID0072,Robles *** Co.,Technology,Trade Credit,194321.95,584,2021-02-02,4.41
+CID0073,Davis *** Bhd,Manufacturing,Trade Credit,302693.74,694,2016-07-04,9.0
+CID0074,Miranda *** Group,Finance,Invoice Financing,28010.14,510,2023-12-29,1.51
+CID0075,Galloway *** Ltd,Manufacturing,Loan,162259.75,447,2019-07-23,5.95
+CID0076,Casey *** Ltd,Construction,Equipment Leasing,156811.98,309,2017-12-17,7.54
+CID0077,Greene *** Holdings,Manufacturing,Invoice Financing,56425.44,741,2020-06-05,5.08
+CID0078,Dunn *** Bhd,Construction,Equipment Leasing,366056.77,790,2019-09-01,5.84
+CID0079,Cunningham *** Group,Healthcare,Invoice Financing,355592.23,490,2021-07-16,3.96
+CID0080,Davies *** Holdings,Manufacturing,Equipment Leasing,299494.57,791,2018-06-05,7.08
+CID0081,Jones *** Enterprises,Healthcare,Invoice Financing,56696.96,538,2016-02-02,9.42
+CID0082,Hartman *** Bhd,Logistics,Trade Credit,66430.83,642,2022-01-08,3.48
+CID0083,Ellison *** Group,Retail,Trade Credit,291418.25,305,2023-12-19,1.54
+CID0084,Roberts *** Co.,Construction,Trade Credit,393546.41,779,2024-04-17,1.21
+CID0085,Bishop *** Co.,Technology,Equipment Leasing,404853.81,806,2016-01-09,9.48
+CID0086,Maldonado *** Ltd,Retail,Equipment Leasing,348195.54,609,2021-09-11,3.81
+CID0087,Weaver *** Enterprises,Manufacturing,Equipment Leasing,348124.43,631,2017-02-25,8.35
+CID0088,Kelly *** Group,Manufacturing,Equipment Leasing,112901.75,637,2023-12-04,1.58
+CID0089,Cobb *** Group,Healthcare,Trade Credit,239103.44,517,2019-09-02,5.83
+CID0090,Valentine *** Group,Healthcare,Overdraft,139919.39,743,2021-09-21,3.78
+CID0091,Brown *** Ltd,Technology,Loan,18079.7,324,2022-09-29,2.76
+CID0092,Nelson *** Bhd,Manufacturing,Loan,329956.35,428,2015-12-19,9.54
+CID0093,Hawkins *** Bhd,Healthcare,Overdraft,286393.93,373,2023-06-14,2.05
+CID0094,Hall *** Ltd,Logistics,Equipment Leasing,386045.85,530,2025-06-02,0.08
+CID0095,Stewart *** Ltd,Healthcare,Loan,59062.03,541,2024-10-28,0.68
+CID0096,Patterson *** Co.,Finance,Overdraft,22690.2,506,2023-08-23,1.86
+CID0097,Reid *** Group,Manufacturing,Overdraft,173108.07,602,2019-11-11,5.64
+CID0098,Gomez *** Holdings,Finance,Invoice Financing,110890.36,340,2019-02-28,6.34
+CID0099,Warner *** Group,Retail,Overdraft,52342.58,643,2019-06-17,6.05
+CID0100,Petty *** Co.,Construction,Trade Credit,496010.68,493,2024-06-08,1.07

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,222 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+import re
+from sklearn.preprocessing import LabelEncoder
+from sklearn.cluster import KMeans
+from sklearn.metrics import silhouette_score
+from collections import defaultdict
+from random import choice
+
+st.set_page_config(page_title="AI Content Strategy App")
+
+st.title("AI Content Strategy App")
+
+
+def optimal_clusters(values, max_clusters=8):
+    X = values.reshape(-1, 1)
+    best_k, best_score = 2, -1
+    for k in range(2, min(max_clusters, len(values)) + 1):
+        km = KMeans(n_clusters=k, n_init="auto", random_state=42)
+        labels = km.fit_predict(X)
+        if len(set(labels)) == 1:
+            continue
+        score = silhouette_score(X, labels)
+        if score > best_score:
+            best_k, best_score = k, score
+    return best_k
+
+
+uploaded = st.file_uploader("Upload customer CSV", type="csv")
+
+if uploaded is not None:
+    df = pd.read_csv(uploaded)
+    df.columns = df.columns.str.lower()
+    required = {"industry", "product", "amount", "credit_score", "tenure"}
+    if not required.issubset(df.columns):
+        st.error(
+            "CSV must contain columns: industry, product, amount, credit_score, tenure"
+        )
+        st.stop()
+
+    ind_enc = LabelEncoder()
+    df["industry_code"] = ind_enc.fit_transform(df["industry"].astype(str))
+
+    ind_k = optimal_clusters(df["industry_code"].values)
+    st.write(f"Detected {ind_k} industry clusters")
+
+    ind_kmeans = KMeans(n_clusters=ind_k, n_init="auto", random_state=42)
+    df["industry_cluster"] = ind_kmeans.fit_predict(df[["industry_code"]])
+
+    df["product_cluster"] = -1
+    prod_cluster_counts = {}
+
+    for i in sorted(df["industry_cluster"].unique()):
+        subset = df[df["industry_cluster"] == i]
+        prod_enc = LabelEncoder()
+        codes = prod_enc.fit_transform(subset["product"].astype(str))
+        n_unique = len(np.unique(codes))
+        if n_unique <= 1:
+            prod_k = 1
+        else:
+            prod_k = optimal_clusters(codes)
+        km = KMeans(n_clusters=prod_k, n_init="auto", random_state=42)
+        df.loc[subset.index, "product_cluster"] = km.fit_predict(codes.reshape(-1, 1))
+        prod_cluster_counts[i] = prod_k
+
+    st.subheader("Industry Cluster Summary")
+    summary = (
+        df.groupby("industry_cluster")
+        .agg(
+            industry=("industry", lambda s: ", ".join(sorted(s.unique()))),
+            total_amount=("amount", "sum"),
+            avg_credit_score=("credit_score", "mean"),
+            avg_tenure=("tenure", "mean"),
+        )
+        .sort_values("total_amount", ascending=False)
+    )
+    st.dataframe(summary)
+
+    sel_ind = st.number_input(
+        "How many ranked industry clusters to include?",
+        min_value=1,
+        max_value=len(summary),
+        value=min(3, len(summary)),
+    )
+    ind_to_use = summary.head(sel_ind).index.tolist()
+
+    selected_prod = defaultdict(int)
+    for i in ind_to_use:
+        prod_df = df[df["industry_cluster"] == i]
+        prod_summary = (
+            prod_df.groupby("product_cluster")
+            .agg(
+                industry=("industry", lambda s: ", ".join(sorted(s.unique()))),
+                product=("product", lambda s: ", ".join(sorted(s.unique()))),
+                total_amount=("amount", "sum"),
+                avg_credit_score=("credit_score", "mean"),
+                avg_tenure=("tenure", "mean"),
+            )
+            .sort_values("total_amount", ascending=False)
+        )
+        max_prod = prod_cluster_counts[i]
+        n_prod = st.number_input(
+            f"Industry cluster {i}: how many top product clusters to include?",
+            min_value=1,
+            max_value=max_prod,
+            value=max_prod,
+        )
+        selected_prod[i] = n_prod
+        st.dataframe(prod_summary)
+
+    msg_keywords = st.text_input(
+        "Keywords or context for marketing messages",
+        key="msg_kw",
+    )
+    prod_keywords = st.text_input(
+        "Keywords or context for product propositions",
+        key="prod_kw",
+    )
+    msg_kw_list = [k.strip() for k in re.split(r"[,\n]+", msg_keywords) if k.strip()]
+    prod_kw_list = [k.strip() for k in re.split(r"[,\n]+", prod_keywords) if k.strip()]
+    num_message_variants = st.number_input(
+        "Number of message variants per industry cluster",
+        min_value=1,
+        max_value=10,
+        value=3,
+    )
+    num_product_props = st.number_input(
+        "Number of product propositions per product cluster",
+        min_value=1,
+        max_value=10,
+        value=3,
+    )
+    temperature = st.slider(
+        "Creative temperature", min_value=0.0, max_value=1.0, value=0.5, step=0.05
+    )
+    use_llm = st.checkbox(
+        "Generate suggestions with Gemma-2B-IT (requires internet and may be slow)",
+        value=False,
+    )
+
+    if st.button("Configure Experiment"):
+        selected_variants = []
+        for i in ind_to_use:
+            prod_df = df[df["industry_cluster"] == i]
+            prod_summary = (
+                prod_df.groupby("product_cluster")
+                .agg(
+                    industry=("industry", lambda s: ", ".join(sorted(s.unique()))),
+                    product=("product", lambda s: ", ".join(sorted(s.unique()))),
+                    total_amount=("amount", "sum"),
+                    avg_credit_score=("credit_score", "mean"),
+                    avg_tenure=("tenure", "mean"),
+                )
+                .sort_values("total_amount", ascending=False)
+            )
+            prods = prod_summary.head(selected_prod[i]).index.tolist()
+            for p in prods:
+                selected_variants.append((i, p))
+
+        def generate_text(prompt):
+            from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+            model_id = "google/gemma-2b-it"
+            tokenizer = AutoTokenizer.from_pretrained(model_id)
+            model = AutoModelForCausalLM.from_pretrained(model_id)
+            pipe = pipeline(
+                "text-generation",
+                model=model,
+                tokenizer=tokenizer,
+                device_map="auto",
+            )
+            out = pipe(
+                prompt,
+                max_new_tokens=100,
+                do_sample=True,
+                temperature=temperature,
+            )
+            return out[0]["generated_text"]
+
+        messages = []
+        if use_llm and (msg_kw_list or prod_kw_list):
+            ind_summary_text = summary.loc[ind_to_use].to_markdown()
+            prod_summary_texts = []
+            for i in ind_to_use:
+                prod_df = df[df["industry_cluster"] == i]
+                prod_summary = (
+                    prod_df.groupby("product_cluster")
+                    .agg(
+                        product=("product", lambda s: ", ".join(sorted(s.unique()))),
+                        total_amount=("amount", "sum"),
+                    )
+                    .sort_values("total_amount", ascending=False)
+                )
+                prod_summary_texts.append(
+                    f"Industry {i}:\n" + prod_summary.head(selected_prod[i]).to_markdown()
+                )
+            prod_text = "\n\n".join(prod_summary_texts)
+            prompt = (
+                f"You are a marketing strategist. Based on the following cluster summaries, propose {num_message_variants} short marketing message variants for each industry cluster using the keywords: {', '.join(msg_kw_list)}. "
+                f"Also propose {num_product_props} product propositions for each product cluster using the keywords: {', '.join(prod_kw_list)}.\n\n"
+                f"Industry clusters:\n{ind_summary_text}\n\nProduct clusters:\n{prod_text}"
+            )
+            try:
+                generated = generate_text(prompt)
+                messages = [line.strip() for line in generated.split("\n") if line.strip()]
+            except Exception as e:
+                messages = [f"LLM generation failed: {e}"]
+
+        assignments = []
+        for _, row in df.iterrows():
+            variant = choice(selected_variants)
+            assignments.append(f"I{variant[0]}-P{variant[1]}")
+        df["variant"] = assignments
+
+        st.subheader("Variant assignments")
+        st.dataframe(df[["industry", "product", "variant"]])
+
+        if messages:
+            st.subheader("AI Suggestions")
+            for m in messages:
+                st.write("-", m)


### PR DESCRIPTION
## Summary
- include sample customers CSV for demonstration
- mention sample file in Readme
- normalise column names in app and dataset
- display more detail in cluster summary tables
- allow comma-separated keywords in app
- refine prompt and split keyword inputs

## Testing
- `python3 -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_686716df2af08329841a559347a74421