### PR TITLE
Use HF InferenceClient and document token requirement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ This project provides a simple Streamlit application for running marketing exper
 - Automatically determines cluster counts for the `industry` column and for the `product` column inside each industry cluster.
 - Performs clustering with K-means and summarises each industry cluster by total amount, average credit score and average tenure, ranking them by total amount.
 - Allows you to pick how many of the ranked industry and product clusters to include when configuring the experiment.
-- Lets you provide separate keywords for marketing messages and product propositions, specify how many of each to generate, adjust a creative temperature slider and optionally generate suggestions using the **Gemma-2B-IT** model hosted on Hugging Face.
+- Lets you provide separate keywords for marketing messages and product propositions, specify how many of each to generate, adjust a creative temperature slider and optionally generate suggestions using the **Gemma-2B-IT** model hosted on Hugging Face (requires setting ``HF_TOKEN``).
 - Randomly assigns customers to message variants.
 
 ## Usage
@@ -34,4 +34,4 @@ automatically normalised to lowercase after upload.
 
 Follow the on-screen instructions to explore clusters, configure your experiment, provide message and product keywords separately and (optionally) generate AI-powered content suggestions.
 
-Gemma model generation requires internet access and may take a long time on first run.
+Gemma model generation requires internet access and an access token for the model on Hugging Face. Set the ``HF_TOKEN`` environment variable with your token before running the app. Generation may take a long time on first run.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn
 torch
 transformers
 tabulate
+huggingface-hub

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -158,25 +158,23 @@ if uploaded is not None:
             for p in prods:
                 selected_variants.append((i, p))
 
-        def generate_text(prompt):
-            from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+        def generate_text(prompt: str) -> str:
+            """Generate text using the Gemma model via the Hugging Face Hub.
+
+            Requires the ``HF_TOKEN`` environment variable to be set with a
+            token that has access to ``google/gemma-2b-it``.
+            """
+            import os
+            from huggingface_hub import InferenceClient
 
             model_id = "google/gemma-2b-it"
-            tokenizer = AutoTokenizer.from_pretrained(model_id)
-            model = AutoModelForCausalLM.from_pretrained(model_id)
-            pipe = pipeline(
-                "text-generation",
-                model=model,
-                tokenizer=tokenizer,
-                device_map="auto",
-            )
-            out = pipe(
+            token = os.getenv("HF_TOKEN")
+            client = InferenceClient(model=model_id, token=token)
+            return client.text_generation(
                 prompt,
                 max_new_tokens=100,
-                do_sample=True,
                 temperature=temperature,
             )
-            return out[0]["generated_text"]
 
         messages = []
         if use_llm and (msg_kw_list or prod_kw_list):


### PR DESCRIPTION
## Summary
- handle gated Gemma model by switching text generation to `InferenceClient`
- document that generation requires `HF_TOKEN`
- add `huggingface-hub` to requirements

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68672a323e4c83299605e98c4fb03ad2