### PR TITLE
Use conversational API for Gemma prompts

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -170,11 +170,14 @@ if uploaded is not None:
             model_id = "google/gemma-2b-it"
             token = os.getenv("HF_TOKEN")
             client = InferenceClient(model=model_id, token=token)
-            return client.text_generation(
-                prompt,
-                max_new_tokens=100,
+            # Use the conversational endpoint for generation
+            messages = [{"role": "user", "content": prompt}]
+            response = client.chat_completion(
+                messages,
+                max_tokens=100,
                 temperature=temperature,
             )
+            return response.choices[0].message.content
 
         messages = []
         if use_llm and (msg_kw_list or prod_kw_list):


### PR DESCRIPTION
## Summary
- update `generate_text` to call `InferenceClient.chat_completion`
- parse the conversational response
- keep clear error handling
- run Streamlit app and tests

## Testing
- `python -m py_compile streamlit_app.py`
- `streamlit run streamlit_app.py --server.headless true --server.port 8501`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867329e8258832986a0136d62c9fdad