### PR TITLE
Update Gemma token limit

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -176,7 +176,7 @@ if uploaded is not None:
             messages = [{"role": "user", "content": prompt}]
             response = client.chat_completion(
                 messages,
-                max_tokens=100,
+                max_tokens=500,
                 temperature=temperature,
             )
             return response.choices[0].message.content


### PR DESCRIPTION
## Summary
- increase Gemma `chat_completion` `max_tokens` from 100 to 500

## Testing
- `grep -n "max_tokens" -R .`

------
https://chatgpt.com/codex/tasks/task_e_686744be76208329b0d5245cb72ad9b7